### PR TITLE
Avoid list to binary conversion

### DIFF
--- a/lib/clickhousex/query.ex
+++ b/lib/clickhousex/query.ex
@@ -38,18 +38,7 @@ defimpl DBConnection.Query, for: Clickhousex.Query do
   def decode(_query, result, _opts) do
     case result.command do
       :selected ->
-        rows = result.rows
-        new_rows = Enum.map(rows, fn el ->
-          list1 = Tuple.to_list(el)
-          Enum.map(list1, fn el1 ->
-            cond do
-              is_list(el1) ->
-                to_string(el1)
-              true ->
-                el1
-            end
-          end)
-        end)
+        new_rows = Enum.map(result.rows, &Tuple.to_list/1)
         Map.put(result, :rows, new_rows)
       _ ->
         result


### PR DESCRIPTION
This allows us to use arrays in Ecto schemas and [aggregate functions](https://clickhouse-docs.readthedocs.io/en/latest/agg_functions/) that return arrays, like `groupUniqArray`.

See [this](https://github.com/appodeal/clickhousex/issues/4) for more information.